### PR TITLE
properly quote shell redirection characters so packages are installed rather than unwanted files being created baca use greater-than functions as redirect operator

### DIFF
--- a/Latent_Diffusion_LAION_400M_model_text_to_image.ipynb
+++ b/Latent_Diffusion_LAION_400M_model_text_to_image.ipynb
@@ -1132,7 +1132,7 @@
         "!git clone https://github.com/crowsonkb/latent-diffusion.git\n",
         "!git clone https://github.com/CompVis/taming-transformers\n",
         "!pip install -e ./taming-transformers\n",
-        "!pip install omegaconf>=2.0.0 pytorch-lightning>=1.0.8 torch-fidelity einops\n",
+        "!pip install \"omegaconf>=2.0.0\" \"pytorch-lightning>=1.0.8\" torch-fidelity einops\n",
         "!pip install transformers\n",
         "!pip install open_clip_torch\n",
         "!pip install autokeras\n",


### PR DESCRIPTION
I'm not sure how this was working for anyone as it was - the unescaped/quoted greater-than characters in the intended "pip install" command on line 1135 will function as a redirection to a file, creating two files: '/content/=2.0.0', and '/content/=1.0.8', containing the output of "pip install omegaconf" and "pip install pytorch-lightning, respectively." This change simply quotes those strings so that pip will be passed the version spec and those extraneous files won't be created.